### PR TITLE
55. Môi trường Dev & Production trong dự án vì sao lại quan trọng?

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,13 @@
     "clean": "rm -rf build && mkdir build",
     "build-babel": "babel ./src -d ./build/src",
     "build": "npm run clean && npm run build-babel",
-    "production": "npm run build && node ./build/src/server.js",
-    "dev": "nodemon --exec babel-node ./src/server.js"
+    "production": "npm run build && cross-env BUILD_MODE=production node ./build/src/server.js",
+    "dev": "cross-env BUILD_MODE=dev nodemon --exec babel-node ./src/server.js"
   },
   "dependencies": {
     "@babel/runtime": "^7.22.10",
     "async-exit-hook": "2.0.1",
+    "cross-env": "7.0.3",
     "dotenv": "16.3.1",
     "express": "^4.18.2",
     "http-status-codes": "2.3.0",

--- a/src/config/environment.js
+++ b/src/config/environment.js
@@ -8,8 +8,12 @@ import 'dotenv/config'
 export const env = {
   MONGODB_URI: process.env.MONGODB_URI,
   DATABASE_NAME: process.env.DATABASE_NAME,
+
   APP_HOST: process.env.APP_HOST,
   APP_PORT: process.env.APP_PORT,
+
+  BUILD_MODE: process.env.BUILD_MODE,
+
 
   AUTHOR: process.env.AUTHOR
 }

--- a/src/middlewares/errorHandlingMiddleware.js
+++ b/src/middlewares/errorHandlingMiddleware.js
@@ -7,7 +7,7 @@
 
 /* eslint-disable no-unused-vars */
 import { StatusCodes } from 'http-status-codes'
-// import { env } from '~/config/environment'
+import { env } from '~/config/environment'
 
 // Middleware xử lý lỗi tập trung trong ứng dụng Back-end NodeJS (ExpressJS)
 export const errorHandlingMiddleware = (err, req, res, next) => {
@@ -24,7 +24,8 @@ export const errorHandlingMiddleware = (err, req, res, next) => {
   // console.error(responseError)
 
   // Chỉ khi môi trường là DEV thì mới trả về Stack Trace để debug dễ dàng hơn, còn không thì xóa đi. (Muốn hiểu rõ hơn hãy xem video 55 trong bộ MERN Stack trên kênh Youtube: https://www.youtube.com/@trungquandev)
-  // if (env.BUILD_MODE !== 'dev') delete responseError.stack
+  // console.log('env.BUILD_MODE: ', env.BUILD_MODE)
+  if (env.BUILD_MODE !== 'dev') delete responseError.stack
 
   // Đoạn này có thể mở rộng nhiều về sau như ghi Error Log vào file, bắn thông báo lỗi vào group Slack, Telegram, Email...vv Hoặc có thể viết riêng Code ra một file Middleware khác tùy dự án.
   // ...

--- a/src/validations/boardValidation.js
+++ b/src/validations/boardValidation.js
@@ -5,7 +5,7 @@
  */
 import Joi from 'joi'
 import { StatusCodes } from 'http-status-codes'
-import ApiError from '~/utils/apiError'
+import ApiError from '~/utils/ApiError'
 
 const createNew = async (req, res, next) => {
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1529,7 +1529,14 @@ core-js@^3.30.2:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.32.0.tgz#7643d353d899747ab1f8b03d2803b0312a0fb3b6"
   integrity sha512-rd4rYZNlF3WuoYuRIDEmbR/ga9CeuWX9U05umAvgrrZoHY4Z++cp/xwPQMvUpBB4Ag6J8KfD80G0zwCyaSxDww==
 
-cross-spawn@^7.0.2:
+cross-env@7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
+cross-spawn@^7.0.1, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
Cái kiến thức này vô cùng quan trọng

Cài đặt cross-env: `yarn add cross-env@^7.0.3`

Nếu cái biến môi trường này không phải là môi trường dev, chúng ta sẽ xóa đi để không trả về nguyên cụm stack trace cho phía client. Thông thường production public ra cho người dùng: `if (env.BUILD_MODE !== 'dev') delete responseError.stack`

Sửa hai lệnh trong production và dev:

```json
"scripts": {
  "lint": "eslint src --ext js --report-unused-disable-directives --max-warnings 0",
  "clean": "rm -rf build && mkdir build",
  "build-babel": "babel ./src -d ./build/src",
  "build": "npm run clean && npm run build-babel",
  "production": "npm run build && cross-env BUILD_MODE=production node ./build/src/server.js",
  "dev": "cross-env BUILD_MODE=dev nodemon --exec babel-node ./src/server.js"
},
```